### PR TITLE
vim-patch:9.0.1183: code is indented more than necessary (#21773)

### DIFF
--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -1396,11 +1396,13 @@ void fixthisline(IndentGetter get_the_indent)
 {
   int amount = get_the_indent();
 
-  if (amount >= 0) {
-    change_indent(INDENT_SET, amount, false, 0, true);
-    if (linewhite(curwin->w_cursor.lnum)) {
-      did_ai = true;  // delete the indent if the line stays empty
-    }
+  if (amount < 0) {
+    return;
+  }
+
+  change_indent(INDENT_SET, amount, false, 0, true);
+  if (linewhite(curwin->w_cursor.lnum)) {
+    did_ai = true;  // delete the indent if the line stays empty
   }
 }
 


### PR DESCRIPTION
Problem:    Code is indented more than necessary.
Solution:   Use an early return where it makes sense. (Yegappan Lakshmanan,
            closes vim/vim#11805)

https://github.com/vim/vim/commit/0233bdfa2b487c392dc4fd1a29113e08fbace334

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>